### PR TITLE
Fix for issue #46

### DIFF
--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -750,7 +750,28 @@ namespace LessMsi.Gui
 			{
 				e.Handled = true;
 				var path = System.Text.RegularExpressions.Regex.Replace(txtMsiFileName.Text.Trim(), "^\"(.+)\"$", "$1");
-				var file = new FileInfo(path);
+				FileInfo file = null;
+				try
+				{
+					file = new FileInfo(path);
+				}
+				catch (ArgumentNullException)
+				{
+					Presenter.Error("The file path is empty");
+				}
+				catch (ArgumentException)
+				{
+					Presenter.Error("The file path is badly formed.");
+				}
+				catch (PathTooLongException)
+				{
+					Presenter.Error("The file path is too long.");
+				}
+				catch (NotSupportedException)
+				{
+					Presenter.Error("The file path contains invalid characters.");
+				}
+				if (file == null) return;
 				if (!file.Exists)
 				{
 					Presenter.Error(string.Format("File '{0}' does not exist.", file.FullName));

--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -749,7 +749,8 @@ namespace LessMsi.Gui
 			if (e.KeyValue == 13)
 			{
 				e.Handled = true;
-				var file = new FileInfo(txtMsiFileName.Text);
+				var path = System.Text.RegularExpressions.Regex.Replace(txtMsiFileName.Text.Trim(), "^\"(.+)\"$", "$1");
+				var file = new FileInfo(path);
 				if (!file.Exists)
 				{
 					Presenter.Error(string.Format("File '{0}' does not exist.", file.FullName));


### PR DESCRIPTION
Fix for issue #46. The first commit in this branch just does a trim and regex replace for path's contained in double quotes (as generated by the windows explorer "Copy as Path" context command). The second, and therefore this pull request, takes that and adds some handling for badly typed paths through use of `Presenter.Error`.