### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 
 				<div style="display:none" id="install-chocolatey-popover">
 					<p>
-						We recommend you install it with chocolatey by simply typing <pre><code>cinst lessmsi</code></pre> at the command line, but you can <a href="https://github.com/activescott/lessmsi/releases/latest" target="_blank">Download</a> and unzip it if you want too.
+						We recommend you install it with chocolatey by simply typing <pre><code>choco install lessmsi</code></pre> at the command line, but you can <a href="https://github.com/activescott/lessmsi/releases/latest" target="_blank">Download</a> and unzip it if you want too.
 					</p>
 					<p>
 						Don't use chocolatey? You should. Visit <a href="http://chocolatey.github.io" target="_blank">chocolatey.github.io</a> to get started.


### PR DESCRIPTION
The current recommendation is to use the choco `install` subcommand. It's not clear if/when the `cinst` style helpers will be obsolete or removed.