### PR TITLE
Fix for #55

### DIFF
--- a/src/LessMsi.Cli/ExtractCommand.cs
+++ b/src/LessMsi.Cli/ExtractCommand.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using NDesk.Options;
 
@@ -15,11 +16,13 @@ namespace LessMsi.Cli
 
 			var i = 0;
 			var msiFile = args[i++];
+			if (!File.Exists(msiFile))
+				throw new OptionException("Invalid argument. Specified msi file does not exist.", "x");
 			var filesToExtract = new List<string>();
 			var extractDir = "";
 			if (i < args.Count)
 			{
-				if (args[i].EndsWith("\\"))
+				if (extractDir == "" && (args[i].EndsWith("\\") || args[i].EndsWith("\"")))
 					extractDir = args[i];
 				else
 					filesToExtract.Add(args[i]);


### PR DESCRIPTION
An example workaround/fix for the \" issue.
I also changed it to only set the extract dir once to conform to the
documentation.
Oh, and it includes an error message, when the msi file doesn't exist,
because I was wondering about the exeption, while I just made a typo...
