### PR TITLE
Make OpenGUICommand work with paths containing spaces

### DIFF
--- a/src/LessMsi.Cli/OpenGuiCommand.cs
+++ b/src/LessMsi.Cli/OpenGuiCommand.cs
@@ -21,11 +21,17 @@ namespace LessMsi.Cli
 			var guiExe = Path.Combine(AppPath, "lessmsi-gui.exe");
 			if (File.Exists(guiExe))
 			{
-				//should we wait for exit?
-				if (args.Count > 0)
-					Process.Start(guiExe, args[1]);
-				else
-					Process.Start(guiExe);
+			    var p = new Process();
+			    p.StartInfo.FileName = guiExe;
+
+			    if (args.Count > 0)
+			    {
+                    // We add double quotes to support paths with spaces, for ex: "E:\Downloads and Sofware\potato.msi".
+                    p.StartInfo.Arguments = string.Format("\"{0}\"", args[1]);
+			        p.Start();
+			    }
+			    else
+			        p.Start();
 			}
 		}
 

--- a/src/LessMsi.Cli/OpenGuiCommand.cs
+++ b/src/LessMsi.Cli/OpenGuiCommand.cs
@@ -21,17 +21,17 @@ namespace LessMsi.Cli
 			var guiExe = Path.Combine(AppPath, "lessmsi-gui.exe");
 			if (File.Exists(guiExe))
 			{
-			    var p = new Process();
-			    p.StartInfo.FileName = guiExe;
+				var p = new Process();
+				p.StartInfo.FileName = guiExe;
 
-			    if (args.Count > 0)
-			    {
-                    // We add double quotes to support paths with spaces, for ex: "E:\Downloads and Sofware\potato.msi".
-                    p.StartInfo.Arguments = string.Format("\"{0}\"", args[1]);
-			        p.Start();
-			    }
-			    else
-			        p.Start();
+				if (args.Count > 0)
+				{
+					// We add double quotes to support paths with spaces, for ex: "E:\Downloads and Sofware\potato.msi".
+					p.StartInfo.Arguments = string.Format("\"{0}\"", args[1]);
+					p.Start();
+				}
+				else
+					p.Start();
 			}
 		}
 

--- a/src/LessMsi.Cli/OpenGuiCommand.cs
+++ b/src/LessMsi.Cli/OpenGuiCommand.cs
@@ -25,7 +25,7 @@ namespace LessMsi.Cli
 				p.StartInfo.FileName = guiExe;
 
 				//should we wait for exit?
-                if (args.Count > 0)
+				if (args.Count > 0)
 				{
 					// We add double quotes to support paths with spaces, for ex: "E:\Downloads and Sofware\potato.msi".
 					p.StartInfo.Arguments = string.Format("\"{0}\"", args[1]);

--- a/src/LessMsi.Cli/OpenGuiCommand.cs
+++ b/src/LessMsi.Cli/OpenGuiCommand.cs
@@ -24,7 +24,8 @@ namespace LessMsi.Cli
 				var p = new Process();
 				p.StartInfo.FileName = guiExe;
 
-				if (args.Count > 0)
+				//should we wait for exit?
+                if (args.Count > 0)
 				{
 					// We add double quotes to support paths with spaces, for ex: "E:\Downloads and Sofware\potato.msi".
 					p.StartInfo.Arguments = string.Format("\"{0}\"", args[1]);


### PR DESCRIPTION
Hi,

I fixed a little issue I had. I tried to explore an .msi file in a folder containing spaces from the Windows context menu, but the LessMSI GUI was unable to find the file. I decided to investigate and found that in [OpenGUICommand.cs](https://github.com/activescott/lessmsi/blob/d74487d1553b99e1cec9d8b095dfd4ddcc77a1b8/src/LessMsi.Cli/OpenGuiCommand.cs#L26), paths were not being quoted. For example, the class would execute the GUI with this command:

    lessmsi-gui o E:\Downloads and software\software.msi

(there are 4 arguments because of the spaces), instead of:

      lessmsi-gui o "E:\Downloads and software\software.msi"

Obviously this is not a problem if the path does not contain spaces.

Now, I wanted to add a test for this...but I don't know how to test this. If you have any ideas let me know.

-Raphaël

