### PR TITLE
Added progress indicator to command line interface

### DIFF
--- a/src/LessMsi.Cli/Program.cs
+++ b/src/LessMsi.Cli/Program.cs
@@ -51,12 +51,12 @@ namespace LessMsi.Cli
 		{
 			try
 			{
-				/** 
-				 * See https://code.google.com/p/lessmsi/wiki/CommandLine for some use cases and docs on commandline parsing.
+                /** 
+				 * See https://github.com/activescott/lessmsi/wiki/Command-Line for some use cases and docs on commandline parsing.
 				 * See https://github.com/mono/mono/blob/master/mcs/tools/mdoc/Mono.Documentation/mdoc.cs#L54  for an example of using "commands" and "subcommands" with the NDesk.Options lib.
 				 */
 
-				var subcommands = new Dictionary<string, LessMsiCommand> {
+                var subcommands = new Dictionary<string, LessMsiCommand> {
 					{"o", new OpenGuiCommand()},
 					{"x", new ExtractCommand()},
 					{"/x", new ExtractCommand()},
@@ -112,10 +112,19 @@ namespace LessMsi.Cli
 
 			Console.WriteLine("Extracting \'" + msiFile + "\' to \'" + outDirName + "\'.");
 
-			Wixtracts.ExtractFiles(msiFile, outDirName, filesToExtract.ToArray());
+			Wixtracts.ExtractFiles(msiFile, outDirName, filesToExtract.ToArray(), PrintProgress);
 		}
 
-	    private static void EnsureFileRooted(ref string sFileName)
+        private static void PrintProgress(IAsyncResult result)
+        {
+            var progress = result as Wixtracts.ExtractionProgress;
+            if (progress == null || string.IsNullOrEmpty(progress.CurrentFileName))
+                return;
+
+            Console.WriteLine(string.Format("{0}/{1}\t{2}", progress.FilesExtractedSoFar + 1, progress.TotalFileCount, progress.CurrentFileName));
+        }
+
+        private static void EnsureFileRooted(ref string sFileName)
 		{
 			if (!Path.IsPathRooted(sFileName))
 				sFileName = Path.Combine(Directory.GetCurrentDirectory(), sFileName);

--- a/src/LessMsi.Core/Msi/Wixtracts.cs
+++ b/src/LessMsi.Core/Msi/Wixtracts.cs
@@ -205,7 +205,7 @@ namespace LessMsi.Msi
 
         public static void ExtractFiles(Path msi, string outputDir)
         {
-            ExtractFiles(msi, outputDir, null, null);
+            ExtractFiles(msi, outputDir, new string[0], null);
         }
 
 		public static void ExtractFiles(Path msi, string outputDir, string[] fileNamesToExtract)
@@ -214,7 +214,13 @@ namespace LessMsi.Msi
 			ExtractFiles(msi, outputDir, msiFiles, null);
 		}
 
-	    private static MsiFile[] GetMsiFileFromFileNames(Path msi, string[] fileNamesToExtract)
+        public static void ExtractFiles(Path msi, string outputDir, string[] fileNamesToExtract, AsyncCallback progressCallback)
+        {
+            var msiFiles = GetMsiFileFromFileNames(msi, fileNamesToExtract);
+            ExtractFiles(msi, outputDir, msiFiles, progressCallback);
+        }
+
+        private static MsiFile[] GetMsiFileFromFileNames(Path msi, string[] fileNamesToExtract)
 	    {
 		    var msiFiles = MsiFile.CreateMsiFilesFromMSI(msi);
 			Array.Sort(msiFiles, (f1, f2) => string.Compare(f1.LongFileName, f2.LongFileName, StringComparison.InvariantCulture));

--- a/src/Lessmsi.Tests/TestBase.cs
+++ b/src/Lessmsi.Tests/TestBase.cs
@@ -94,7 +94,7 @@ namespace LessMsi.Tests
             //LessMsi.Program.DoExtraction(GetMsiTestFile(msiFileName).FullName, outputDir);
             if (fileNamesToExtractOrNull == null)
             {	//extract everything:
-                LessMsi.Msi.Wixtracts.ExtractFiles(GetMsiTestFile(msiFileName), outputDir, null, null);	
+                LessMsi.Msi.Wixtracts.ExtractFiles(GetMsiTestFile(msiFileName), outputDir);	
             }
             else
             {


### PR DESCRIPTION
This is a change made to the command line version of lessmsi for integration into Universal Extractor. It adds a progress display, written to stdout for each file extracted.

Example:
```
Extracting '<file.msi>' to '<folder>'.
1/296   license.txt
2/296   readme.txt
...
```

I think it's nicer for the user to see how far the extraction progress went, so you might want to add the change to the official repository. But it's just a suggestion :)