### PR TITLE
[WIP] Issue #116 in progress...

### DIFF
--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -920,9 +920,14 @@ namespace LessMsi.Gui
 
 
 					var filesToExtract = selectedFiles.ToArray();
-					Wixtracts.ExtractFiles(msiFile, outputDir, filesToExtract,
-					                       new AsyncCallback(progressDialog.UpdateProgress));
-				}
+					Wixtracts.ExtractFiles(msiFile, 
+                        outputDir, 
+                        filesToExtract,
+					    new AsyncCallback(progressDialog.UpdateProgress),
+                        progressDialog.ExtractionErrorHandler
+                    );
+                    progressDialog.ShowAnyFinalMessages();
+                }
 				catch (Exception err)
 				{
 					MessageBox.Show(this,


### PR DESCRIPTION
A fix/implementation to resolve #116 

- [x] Prompt the user to allow them to abort or continue extraction.
- [x] Ignore all - Don't force the user to click "continue" on every single file as many may fail. Let them tell the app to ignore all other errors.
- [x] At the end of the extraction, if errors did occur:
    -  [x] inform the user again with more detail about what files failed.
    -  [ ] Encourage them to report the errors to https://github.com/activescott/lessmsi/issues
- [ ] Do it in GUI
- [ ] Do it in CLI
