### PR TITLE
Avoids HTTPS Downgrade via Redirect Chain

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,8 +113,8 @@
 				</section>
 
 				<footer>
-					<a href="https://internetdefenseleague.org">
-						<img src="https://internetdefenseleague.org/images/badges/final/footer_badge.png" 
+					<a href="https://www.internetdefenseleague.org">
+						<img src="https://www.internetdefenseleague.org/images/badges/final/footer_badge.png" 
 							height="80"
 							style="float:left; margin:0 10px 10px 0"
 							alt="Member of The Internet Defense League"/>


### PR DESCRIPTION
Unfortunately, `https://internetdefenseleague.com` redirects to the non-secure `http://www.*`, which itself redirects to the secure `https://www.*`.

![image](https://user-images.githubusercontent.com/815158/103421185-a6a97880-4b60-11eb-8421-a676dd0b76c5.png)

The suggested change avoids the redirects entirely, linking to the desired resource directly, and preserving the initial HTTPS connection.

- [ ] Added tests for any bug fixes that changed existing code
- [ ] Added tests for any new behavior
- [ ] All unit tests are passing (please make sure all tests are passing for your branch/PR at https://ci.appveyor.com/project/activescott/lessmsi/history )

cc @activescott 