### PR TITLE
refactor: Rename DataGridView Extensions

### DIFF
--- a/src/LessMsi.Gui/Extensions/DataGridViewExtensions.cs
+++ b/src/LessMsi.Gui/Extensions/DataGridViewExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Windows.Forms;
 
-namespace LessMsi.Gui.Windows.Forms
+namespace LessMsi.Gui.Extensions
 {
-	public static class DataGridViewExtensionMethods
+	public static class DataGridViewExtensions
 	{
 		/// <summary>
 		/// Adjusts the width of all columns to fit the contents of all cells.

--- a/src/LessMsi.Gui/LessMsi.Gui.csproj
+++ b/src/LessMsi.Gui/LessMsi.Gui.csproj
@@ -94,7 +94,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
-    <Compile Include="Windows.Forms\DataGridViewExtensionMethods.cs" />
+    <Compile Include="Extensions\DataGridViewExtensions.cs" />
     <Compile Include="Windows.Forms\DisposableCursor.cs" />
     <Compile Include="Windows.Forms\ElevationButton.cs">
       <SubType>Component</SubType>

--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -30,6 +30,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
+using LessMsi.Gui.Extensions;
 using LessMsi.Gui.Model;
 using LessMsi.Gui.Windows.Forms;
 using LessMsi.Msi;


### PR DESCRIPTION
This brings it in line with other extension methods, following #158
