### PR TITLE
feat: added ability to save and load app window size and location

### DIFF
--- a/src/LessMsi.Gui/LessMsi.Gui.csproj
+++ b/src/LessMsi.Gui/LessMsi.Gui.csproj
@@ -47,6 +47,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />

--- a/src/LessMsi.Gui/app.config
+++ b/src/LessMsi.Gui/app.config
@@ -4,4 +4,11 @@
 	<supportedRuntime version="v4.0"/>
 	<supportedRuntime version="v4.5"/>
 </startup>
+  <appSettings>
+    <add key="WindowWidth" value="0"/>
+    <add key="WindowHeight" value="0"/>
+
+    <add key="X_Position" value="10"/>
+    <add key="Y_Position" value="10"/>
+  </appSettings>
 </configuration>


### PR DESCRIPTION
:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:

Please fill out the following checklist:

- [ ] Added tests for any bug fixes that changed existing code
- [ ] Added tests for any new behavior
- [ ] All unit tests are passing (please make sure all tests are passing for your branch/PR at https://ci.appveyor.com/project/activescott/lessmsi/history )

If you need any help at all, feel free to submit the PR and @-mention activescott and I'll be happy to assist!

Hello @activescott

I took care of this [ticket](https://github.com/activescott/lessmsi/issues/95).
I added a configuration that saves the last size and position of the app and loads them during app startup.
The change is purely on the UI side of the app, so I didnt run any tests.

Thank you.

fixes #95