### PR TITLE
build: adds a new required argument to choco push; does github publish first so if that works we can ignore chocolatey

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -22,11 +22,6 @@ You can install or upgrade by extracting all files from the zip attached to this
         `
       }
     }],
-    ["@semantic-release/exec", {
-      "verifyConditionsCmd": "src\\.build\\semantic-release-verify.cmd",
-      "prepareCmd": "src\\.build\\semantic-release-prepare.cmd ${nextRelease.version}",
-      "publishCmd": "src\\.build\\semantic-release-publish.cmd ${nextRelease.version}",
-    }],
     // github config docs: https://github.com/semantic-release/github
     ["@semantic-release/github", {
       "assets": [
@@ -34,5 +29,10 @@ You can install or upgrade by extracting all files from the zip attached to this
         {"path": "src/.deploy/*.zip", "label": "Zip of lessmsi application binaries"}
       ]
     }],
+    ["@semantic-release/exec", {
+      "verifyConditionsCmd": "src\\.build\\semantic-release-verify.cmd",
+      "prepareCmd": "src\\.build\\semantic-release-prepare.cmd ${nextRelease.version}",
+      "publishCmd": "src\\.build\\semantic-release-publish.cmd ${nextRelease.version}",
+    }],    
   ]
 };

--- a/src/.build/semantic-release-publish.cmd
+++ b/src/.build/semantic-release-publish.cmd
@@ -13,7 +13,7 @@ set _BUILD_VERSION=%1
 
 ECHO Running choco push...
 
-choco push "%THIS_DIR%..\.deploy\chocolateypackage\lessmsi.%_BUILD_VERSION%.nupkg" --api-key=%CHOCO_KEY%
+choco push --source https://push.chocolatey.org/ --api-key=%CHOCO_KEY% "%THIS_DIR%..\.deploy\chocolateypackage\lessmsi.%_BUILD_VERSION%.nupkg"
 
 REM NOTE: ECHO does not clear/set errorlevel https://ss64.com/nt/errorlevel.htmls
 ECHO Running choco push complete. Errorlevel was %ERRORLEVEL%


### PR DESCRIPTION
closes #200 