### PR TITLE
added architecture flag to files extraction command

### DIFF
--- a/src/LessMsi.Cli/App.config
+++ b/src/LessMsi.Cli/App.config
@@ -1,7 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<startup>
-		<supportedRuntime version="v4.0"/>
-		<supportedRuntime version="v4.5"/>
+		<supportedRuntime version="v4.0" />
+		<supportedRuntime version="v4.5" />
 	</startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/LessMsi.Cli/ArchitectureType.cs
+++ b/src/LessMsi.Cli/ArchitectureType.cs
@@ -1,0 +1,18 @@
+﻿namespace LessMsi.Cli
+{
+    public enum ArchitectureType
+    {
+        /// <summary>
+        /// Default value indicating no architecture.
+        /// </summary>
+        None,
+        /// <summary>
+        /// Value indicating a 32 bit architecture.
+        /// </summary>
+        X32,
+        /// <summary>
+        /// Value indicating a 64 bit architecture.
+        /// </summary>
+        X64
+    }
+}

--- a/src/LessMsi.Cli/ExtractCommand.cs
+++ b/src/LessMsi.Cli/ExtractCommand.cs
@@ -56,20 +56,20 @@ namespace LessMsi.Cli
         {
             ArchitectureType architectureType = ArchitectureType.None;
 
-            foreach (string arg in allArgs) 
+            foreach (string arg in allArgs)
             {
                 if (arg.Contains("-a"))
                 {
                     string rawArchitecture = arg.Split('=')[1];
-                    switch (rawArchitecture) 
+                    if (rawArchitecture == "32")
                     {
-                        case "32":
-                            architectureType = ArchitectureType.X64;
-                            break;
-                        case "64":
-                            architectureType = ArchitectureType.X32;
-                            break;
+                        architectureType = ArchitectureType.X64;
                     }
+                    else if (rawArchitecture == "64")
+                    {
+                        architectureType = ArchitectureType.X32;
+                    }
+
                     break;
                 }
             }

--- a/src/LessMsi.Cli/ExtractCommand.cs
+++ b/src/LessMsi.Cli/ExtractCommand.cs
@@ -30,7 +30,9 @@ namespace LessMsi.Cli
             while (++i < args.Count)
                 filesToExtract.Add(args[i]);
 
-            Program.DoExtraction(msiFile, extractDir.TrimEnd('\"'), filesToExtract, getExtractionMode(allArgs[0]));
+            ExtractionMode extractionMode = getExtractionMode(allArgs[0]);
+            ArchitectureType architectureType = getInverseArchitectureType(allArgs);
+            Program.DoExtraction(msiFile, extractDir.TrimEnd('\"'), filesToExtract, extractionMode, architectureType);
         }
 
         private ExtractionMode getExtractionMode(string commandArgument)
@@ -48,6 +50,33 @@ namespace LessMsi.Cli
             }
 
             return extractionMode;
+        }
+
+        private ArchitectureType getInverseArchitectureType(List<string> allArgs)
+        {
+            ArchitectureType architectureType = ArchitectureType.None;
+
+            foreach (string arg in allArgs) 
+            {
+                if (arg.Contains("-a"))
+                {
+                    string rawArchitecture = arg.Split('=')[1];
+                    switch (rawArchitecture) 
+                    {
+                        case "32":
+                            architectureType = ArchitectureType.X64;
+                            break;
+                        case "64":
+                            architectureType = ArchitectureType.X32;
+                            break;
+                        default:
+                            throw new System.Exception($"Unknown architecture {rawArchitecture} type was entered");
+                    }
+                    break;
+                }
+            }
+
+            return architectureType;
         }
     }
 }

--- a/src/LessMsi.Cli/ExtractCommand.cs
+++ b/src/LessMsi.Cli/ExtractCommand.cs
@@ -69,8 +69,6 @@ namespace LessMsi.Cli
                         case "64":
                             architectureType = ArchitectureType.X32;
                             break;
-                        default:
-                            throw new System.Exception($"Unknown architecture {rawArchitecture} type was entered");
                     }
                     break;
                 }

--- a/src/LessMsi.Cli/LessMsi.Cli.csproj
+++ b/src/LessMsi.Cli/LessMsi.Cli.csproj
@@ -45,7 +45,26 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.8.0.0\lib\net462\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.8.0.0\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="wix">
       <HintPath>..\..\lib\wix.dll</HintPath>
     </Reference>
@@ -54,6 +73,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ArchitectureType.cs" />
     <Compile Include="ExtractionMode.cs" />
     <Compile Include="ExtractCommand.cs" />
     <Compile Include="LessMsiCommand.cs" />

--- a/src/LessMsi.Cli/Program.cs
+++ b/src/LessMsi.Cli/Program.cs
@@ -259,14 +259,13 @@ namespace LessMsi.Cli
                 using (var reader = new PEReader(stream))
                 {
                     var headers = reader.PEHeaders;
-                    switch (headers.PEHeader.Magic)
+                    if (headers.PEHeader.Magic == PEMagic.PE32)
                     {
-                        case PEMagic.PE32:
-                            architectureType = ArchitectureType.X32;
-                            break;
-                        case PEMagic.PE32Plus:
-                            architectureType = ArchitectureType.X64;
-                            break;
+                        architectureType = ArchitectureType.X32;
+                    }
+                    else if (headers.PEHeader.Magic == PEMagic.PE32Plus)
+                    {
+                        architectureType = ArchitectureType.X64;
                     }
                 }
             }

--- a/src/LessMsi.Cli/packages.config
+++ b/src/LessMsi.Cli/packages.config
@@ -1,4 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="LessIO" version="1.0.34" targetFramework="net40" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="8.0.0" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Reflection.Metadata" version="8.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
 </packages>

--- a/src/Lessmsi.Tests/LessMsi.Tests.csproj
+++ b/src/Lessmsi.Tests/LessMsi.Tests.csproj
@@ -108,6 +108,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Lessmsi.Tests/app.config
+++ b/src/Lessmsi.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:

Please fill out the following checklist:

- [ ] Added tests for any bug fixes that changed existing code
- [ ] Added tests for any new behavior
- [ ] All unit tests are passing (please make sure all tests are passing for your branch/PR at https://ci.appveyor.com/project/activescott/lessmsi/history )


If you need any help at all, feel free to submit the PR and @-mention activescott and I'll be happy to assist!

Hello @activescott.

I took care of this [ticket](https://github.com/activescott/lessmsi/issues/187), and for now I submit a first pull request for your consideration.
The idea behind this update is similar to the approach used in the flat extraction feature. 
First, I perform a regular file extraction using the x command, and then I delete any PE files that belong to the architecture opposite to the one specified by the user with the `-a` flag.

Please note that are different files with the `.duplicate1` suffix.
These are various text files with different extensions that are not architecture specific.

For example:
![image](https://github.com/user-attachments/assets/32fa7f4f-0374-4cb2-bb8a-5f2fa09ca9b0)
However, I don't think they contain valuable information for the user, unlike other PE files that I handle in this update.

Once you are happy with the presented solution, I will added additional test cases for the new feature. 


Thank you.