### PR TITLE
Amending Italian Translations

### DIFF
--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -57,6 +57,10 @@ namespace LessMsi.Gui
 
         public MainForm(string defaultInputFile)
 		{
+            var culture = CultureInfo.CreateSpecificCulture("it-IT");
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+
             InitializeComponent();
 			msiTableGrid.AutoGenerateColumns = false;
 			msiPropertyGrid.AutoGenerateColumns = false;
@@ -691,7 +695,7 @@ namespace LessMsi.Gui
             // openMsiDialog
             // 
             this.openMsiDialog.DefaultExt = "msi";
-            this.openMsiDialog.Filter = "msierablefiles|*.msi;*.msp|All Files|*.*";
+            this.openMsiDialog.Filter = $"{Strings.MsiFilesFilter}|*.msi;*.msp|{Strings.AllFilesFilter}|*.*";
             // 
             // statusBar1
             // 

--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -57,10 +57,6 @@ namespace LessMsi.Gui
 
         public MainForm(string defaultInputFile)
 		{
-            var culture = CultureInfo.CreateSpecificCulture("it-IT");
-            CultureInfo.CurrentCulture = culture;
-            CultureInfo.CurrentUICulture = culture;
-
             InitializeComponent();
 			msiTableGrid.AutoGenerateColumns = false;
 			msiPropertyGrid.AutoGenerateColumns = false;

--- a/src/LessMsi.Gui/Resources/Languages/Strings.Designer.cs
+++ b/src/LessMsi.Gui/Resources/Languages/Strings.Designer.cs
@@ -88,6 +88,15 @@ namespace LessMsi.Gui.Resources.Languages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to All Files.
+        /// </summary>
+        internal static string AllFilesFilter {
+            get {
+                return ResourceManager.GetString("AllFilesFilter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The file path is badly formed.
         /// </summary>
         internal static string BadlyFormedFilePathError {
@@ -282,6 +291,15 @@ namespace LessMsi.Gui.Resources.Languages {
         internal static string MissingFile {
             get {
                 return ResourceManager.GetString("MissingFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to msierablefiles.
+        /// </summary>
+        internal static string MsiFilesFilter {
+            get {
+                return ResourceManager.GetString("MsiFilesFilter", resourceCulture);
             }
         }
         

--- a/src/LessMsi.Gui/Resources/Languages/Strings.it.resx
+++ b/src/LessMsi.Gui/Resources/Languages/Strings.it.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="About" xml:space="preserve">
-    <value>Info Programma</value>
+    <value>Info programma</value>
   </data>
   <data name="Component" xml:space="preserve">
     <value>Componente</value>
@@ -145,10 +145,10 @@
     <value>E&amp;strai</value>
   </data>
   <data name="ExtractFiles" xml:space="preserve">
-    <value>Estrai File</value>
+    <value>Estrai file</value>
   </data>
   <data name="ExtractStreamFiles" xml:space="preserve">
-    <value>Estrai File Flussi...</value>
+    <value>Estrai file flussi...</value>
   </data>
   <data name="File" xml:space="preserve">
     <value>File</value>
@@ -166,13 +166,13 @@
     <value>Preferenze</value>
   </data>
   <data name="RecentFiles" xml:space="preserve">
-    <value>File Recenti</value>
+    <value>File recenti</value>
   </data>
   <data name="SearchFile" xml:space="preserve">
-    <value>Cerca File</value>
+    <value>Cerca file</value>
   </data>
   <data name="SelectAll" xml:space="preserve">
-    <value>Selziona &amp;Tutto</value>
+    <value>Selziona &amp;tutto</value>
   </data>
   <data name="Size" xml:space="preserve">
     <value>Dimensione</value>
@@ -190,13 +190,13 @@
     <value>&amp;Tabella</value>
   </data>
   <data name="TableView" xml:space="preserve">
-    <value>Vista Tabella</value>
+    <value>Vista tabella</value>
   </data>
   <data name="Type" xml:space="preserve">
     <value>Tipo</value>
   </data>
   <data name="UnselectAll" xml:space="preserve">
-    <value>&amp;Deseleziona Tutto</value>
+    <value>&amp;Deseleziona tutto</value>
   </data>
   <data name="Value" xml:space="preserve">
     <value>Valore</value>
@@ -232,19 +232,19 @@
     <value>Il percorso del file è troppo lungo</value>
   </data>
   <data name="AddShortcutText" xml:space="preserve">
-    <value>Aggiungi menu contestuale Explorer</value>
+    <value>Aggiungi menu contestuale explorer</value>
   </data>
   <data name="AddShortcutTextNote" xml:space="preserve">
     <value>Aggiungi le voci 'Estrai' e 'Sfoglia' al menu contestuale dei file .msi</value>
   </data>
   <data name="RemoveShortcutText" xml:space="preserve">
-    <value>Rimuovi menu contestuale Explorer</value>
+    <value>Rimuovi menu contestuale explorer</value>
   </data>
   <data name="RemoveShortcutTextNote" xml:space="preserve">
-    <value>Rimuovi se esistono voci menu contestuale Explorer</value>
+    <value>Rimuovi se esistono voci menu contestuale explorer</value>
   </data>
   <data name="MissingFile" xml:space="preserve">
-    <value>File Mancante</value>
+    <value>File mancante</value>
   </data>
   <data name="SameDirMassage" xml:space="preserve">
     <value>deve essere nella stessa cartella di</value>

--- a/src/LessMsi.Gui/Resources/Languages/Strings.it.resx
+++ b/src/LessMsi.Gui/Resources/Languages/Strings.it.resx
@@ -276,4 +276,10 @@
   <data name="PreferencesMenuLabel" xml:space="preserve">
     <value>&amp;Preferenze</value>
   </data>
+  <data name="AllFilesFilter" xml:space="preserve">
+    <value>Tutti i file</value>
+  </data>
+  <data name="MsiFilesFilter" xml:space="preserve">
+    <value>File eseguibili .msi</value>
+  </data>
 </root>

--- a/src/LessMsi.Gui/Resources/Languages/Strings.resx
+++ b/src/LessMsi.Gui/Resources/Languages/Strings.resx
@@ -126,6 +126,9 @@
   <data name="AddShortcutTextNote" xml:space="preserve">
     <value>Adds 'Extract' &amp; 'Explore' menu items to the right-click context menu of .msi files</value>
   </data>
+  <data name="AllFilesFilter" xml:space="preserve">
+    <value>All Files</value>
+  </data>
   <data name="BadlyFormedFilePathError" xml:space="preserve">
     <value>The file path is badly formed</value>
   </data>
@@ -191,6 +194,9 @@
   </data>
   <data name="MissingFile" xml:space="preserve">
     <value>Missing File</value>
+  </data>
+  <data name="MsiFilesFilter" xml:space="preserve">
+    <value>msierablefiles</value>
   </data>
   <data name="Name" xml:space="preserve">
     <value>Name</value>

--- a/src/Lessmsi.Tests/GUITests.cs
+++ b/src/Lessmsi.Tests/GUITests.cs
@@ -48,8 +48,8 @@ namespace LessMsi.Tests
             Assert.NotNull(form);
 
             // check buttons strings
-            Assert.Equal("Selziona &Tutto", form.btnSelectAll.Text);
-            Assert.Equal("&Deseleziona Tutto", form.btnUnselectAll.Text);
+            Assert.Equal("Selziona &tutto", form.btnSelectAll.Text);
+            Assert.Equal("&Deseleziona tutto", form.btnUnselectAll.Text);
             Assert.Equal("E&strai", form.btnExtract.Text);
 
             // check strip menu items strings


### PR DESCRIPTION
:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:

Please fill out the following checklist:

- [x] Added tests for any bug fixes that changed existing code
- [x] Added tests for any new behavior
- [x] All unit tests are passing (please make sure all tests are passing for your branch/PR at https://ci.appveyor.com/project/activescott/lessmsi/history )


If you need any help at all, feel free to submit the PR and @-mention activescott and I'll be happy to assist!

Hello @activescott.

I took care of this [ticket](https://github.com/activescott/lessmsi/issues/206).

Here is the amended file filter translation:
![image](https://github.com/user-attachments/assets/3777df57-8964-4cd7-86ef-d064d9d55c56)

@bovirus, I took the liberty and amended the Italian translations where upper case words should be lowercase.
For example:
![image](https://github.com/user-attachments/assets/2c9bd48b-48c8-4a91-a56e-ae3d86427239)

I also amended the tests to use the new and correct translations

Thank you.