### PR TITLE
Improved UI update logic after language change for better buttons spa…

### DIFF
--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -454,7 +454,6 @@ namespace LessMsi.Gui
             // btnSelectAll
             // 
             this.btnSelectAll.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnSelectAll.Location = new System.Drawing.Point(0, 9);
             this.btnSelectAll.Name = "btnSelectAll";
             this.btnSelectAll.TabIndex = 1;
             this.btnSelectAll.Text = Strings.SelectAll;
@@ -462,12 +461,11 @@ namespace LessMsi.Gui
             this.btnSelectAll.AutoSize = true;
             this.btnSelectAll.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             this.btnSelectAll.AutoEllipsis = false;
-            updateButtonSize(this.btnSelectAll);
+            UpdateButtonSize(this.btnSelectAll);
             // 
             // btnUnselectAll
             // 
             this.btnUnselectAll.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnUnselectAll.Location = new System.Drawing.Point(106, 9);
             this.btnUnselectAll.Name = "btnUnselectAll";
             this.btnUnselectAll.TabIndex = 2;
             this.btnUnselectAll.Text = Strings.UnselectAll;
@@ -475,13 +473,12 @@ namespace LessMsi.Gui
             this.btnUnselectAll.AutoSize = true;
             this.btnUnselectAll.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             this.btnUnselectAll.AutoEllipsis = false;
-            updateButtonSize(this.btnUnselectAll);
+            UpdateButtonSize(this.btnUnselectAll);
             // 
             // btnExtract
             //
             this.btnExtract.Enabled = false;
             this.btnExtract.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnExtract.Location = new System.Drawing.Point(212, 9);
             this.btnExtract.Name = "btnExtract";
             this.btnExtract.TabIndex = 3;
             this.btnExtract.Text = Strings.Extract;
@@ -489,7 +486,7 @@ namespace LessMsi.Gui
             this.btnExtract.AutoSize = true;
             this.btnExtract.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             this.btnExtract.AutoEllipsis = false;
-            updateButtonSize(this.btnExtract);
+            UpdateButtonSize(this.btnExtract);
             // 
             // tabTableView
             // 
@@ -874,7 +871,7 @@ namespace LessMsi.Gui
             UpdateButtonLayout(panel2);
         }
 
-        private void updateButtonSize(Button btn)
+        private void UpdateButtonSize(Button btn)
         {
             using (Graphics cg = this.CreateGraphics())
             {

--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -291,9 +291,23 @@ namespace LessMsi.Gui
 
         #region Windows Form Designer generated code
 
+        private bool m_bLangChangeFlag = false;
+
         private int SelectAllButtonArea => Strings.SelectAll.Length * 6;
         private int UnselectAllButtonArea => Strings.UnselectAll.Length * 7;
         private int ExtractButtonArea => Strings.Extract.Length * 7;
+        private int LangChangeAddition
+        {
+            get
+            {
+                if (m_bLangChangeFlag)
+                {
+                    return 10;
+                }
+
+                return 0;
+            }
+        }
 
         /// <summary>
         /// Required method for Designer support - do not modify
@@ -486,7 +500,7 @@ namespace LessMsi.Gui
             //
             this.btnExtract.Enabled = false;
             this.btnExtract.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnExtract.Location = new System.Drawing.Point(SelectAllButtonArea + UnselectAllButtonArea + 10, 9);
+            this.btnExtract.Location = new System.Drawing.Point(SelectAllButtonArea + UnselectAllButtonArea + LangChangeAddition, 9);
             this.btnExtract.Name = "btnExtract";
             this.btnExtract.Size = new System.Drawing.Size(ExtractButtonArea, 27);
             this.btnExtract.TabIndex = 3;
@@ -1037,6 +1051,7 @@ namespace LessMsi.Gui
             string newSelectedLanguage = changeLanguageForm.NewSelectedLanguage;
             if (newSelectedLanguage != string.Empty)
             {
+                m_bLangChangeFlag = true;
                 Thread.CurrentThread.CurrentUICulture = CultureInfo.CreateSpecificCulture(newSelectedLanguage);
 
                 Controls.Clear();

--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -290,25 +290,6 @@ namespace LessMsi.Gui
         }
 
         #region Windows Form Designer generated code
-
-        private bool m_bLangChangeFlag = false;
-
-        private int SelectAllButtonArea => Strings.SelectAll.Length * 6;
-        private int UnselectAllButtonArea => Strings.UnselectAll.Length * 7;
-        private int ExtractButtonArea => Strings.Extract.Length * 7;
-        private int LangChangeAddition
-        {
-            get
-            {
-                if (m_bLangChangeFlag)
-                {
-                    return 10;
-                }
-
-                return 0;
-            }
-        }
-
         /// <summary>
         /// Required method for Designer support - do not modify
         /// the contents of this method with the code editor.
@@ -475,40 +456,40 @@ namespace LessMsi.Gui
             this.btnSelectAll.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.btnSelectAll.Location = new System.Drawing.Point(0, 9);
             this.btnSelectAll.Name = "btnSelectAll";
-            this.btnSelectAll.Size = new System.Drawing.Size(SelectAllButtonArea, 27);
             this.btnSelectAll.TabIndex = 1;
             this.btnSelectAll.Text = Strings.SelectAll;
             this.btnSelectAll.Click += new System.EventHandler(this.btnSelectAll_Click);
             this.btnSelectAll.AutoSize = true;
             this.btnSelectAll.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             this.btnSelectAll.AutoEllipsis = false;
+            updateButtonSize(this.btnSelectAll);
             // 
             // btnUnselectAll
             // 
             this.btnUnselectAll.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnUnselectAll.Location = new System.Drawing.Point(SelectAllButtonArea + 5, 9);
+            this.btnUnselectAll.Location = new System.Drawing.Point(106, 9);
             this.btnUnselectAll.Name = "btnUnselectAll";
-            this.btnUnselectAll.Size = new System.Drawing.Size(UnselectAllButtonArea, 27);
             this.btnUnselectAll.TabIndex = 2;
             this.btnUnselectAll.Text = Strings.UnselectAll;
             this.btnUnselectAll.Click += new System.EventHandler(this.btnUnselectAll_Click);
             this.btnUnselectAll.AutoSize = true;
             this.btnUnselectAll.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             this.btnUnselectAll.AutoEllipsis = false;
+            updateButtonSize(this.btnUnselectAll);
             // 
             // btnExtract
             //
             this.btnExtract.Enabled = false;
             this.btnExtract.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnExtract.Location = new System.Drawing.Point(SelectAllButtonArea + UnselectAllButtonArea + LangChangeAddition, 9);
+            this.btnExtract.Location = new System.Drawing.Point(212, 9);
             this.btnExtract.Name = "btnExtract";
-            this.btnExtract.Size = new System.Drawing.Size(ExtractButtonArea, 27);
             this.btnExtract.TabIndex = 3;
             this.btnExtract.Text = Strings.Extract;
             this.btnExtract.Click += new System.EventHandler(this.btnExtract_Click);
             this.btnExtract.AutoSize = true;
             this.btnExtract.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             this.btnExtract.AutoEllipsis = false;
+            updateButtonSize(this.btnExtract);
             // 
             // tabTableView
             // 
@@ -890,12 +871,35 @@ namespace LessMsi.Gui
             this.ResumeLayout(false);
             this.PerformLayout();
 
+            UpdateButtonLayout(panel2);
         }
 
+        private void updateButtonSize(Button btn)
+        {
+            using (Graphics cg = this.CreateGraphics())
+            {
+                SizeF size = cg.MeasureString(btn.Text, btn.Font);
+                btn.Width = (int)size.Width;
+            }
+        }
+
+        private void UpdateButtonLayout(Panel panel)
+        {
+            int margin = 5;
+            var buttons = panel.Controls.OfType<Button>().ToList();
+
+            int startX = 0;
+            int y = (panel.Height - buttons[0].Height) / 2;
+
+            foreach (var button in buttons)
+            {
+                button.Location = new Point(startX, y);
+                startX += button.Width + margin;
+            }
+        }
         #endregion
 
         #endregion
-
 
         private void OpenFileCommand()
         {
@@ -1051,7 +1055,6 @@ namespace LessMsi.Gui
             string newSelectedLanguage = changeLanguageForm.NewSelectedLanguage;
             if (newSelectedLanguage != string.Empty)
             {
-                m_bLangChangeFlag = true;
                 Thread.CurrentThread.CurrentUICulture = CultureInfo.CreateSpecificCulture(newSelectedLanguage);
 
                 Controls.Clear();


### PR DESCRIPTION
:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:

Please fill out the following checklist:

- [ ] Added tests for any bug fixes that changed existing code
- [ ] Added tests for any new behavior
- [ ] All unit tests are passing (please make sure all tests are passing for your branch/PR at https://ci.appveyor.com/project/activescott/lessmsi/history )


If you need any help at all, feel free to submit the PR and @-mention activescott and I'll be happy to assist!

Hello @activescott and @bovirus.

I created this pull request with updated logic for this [ticket](https://github.com/activescott/lessmsi/issues/220).
I improved the UI update logic after language change for better buttons spacing.

At app startup:
![image](https://github.com/user-attachments/assets/ca0db975-bfa0-41cd-805a-70578ab9b93f)

After language change:
![image](https://github.com/user-attachments/assets/c590e912-7612-41de-9319-951cefeb86cb)

The buttons sizes are a little bit different after language changes, and it was done to avoid a case where the buttons overlap due to changing button text length.
You can see equal spacing between the buttons in the attached images

Thanks