### PR TITLE
chore: update expired GH_TOKEN secret for appveyor/semantic release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ image: Visual Studio 2022
 environment:
   # from https://github.com/settings/tokens encrypted at https://ci.appveyor.com/tools/encrypt
   GH_TOKEN:
-    secure: MJhg1HrP+chjNOM6GAdrQ957321OGuvKqKKiHfOM7igvzwDf36FQw7AHstrUxOOeY+QHh9spKK4y/s/YB+GIJ+vFjl4x+AXMOVio90NOGpMU+r19DimdewGg+im4Ca9U
+    secure: MJhg1HrP+chjNOM6GAdrQzMWMTHNwmzD57kWT7mhWwnOOJiag1EZHHgVtrTUmGJ1syJncgmKTVofdOND+9QmqbpbMji6V0eN9EPXN6t+Os78H+wuCj58GLWjel0x+nM9
   CHOCO_KEY:
     secure: /Ie5xuB5GTDwElbSN0V+mCyYtYNhfQJRjdoWFUsNsVJW9bq32LNzSlI1cn4OUxIu
 


### PR DESCRIPTION
Semantic release tried to deploy and couldn't becuase the GH_TOKEN was expred:

> '**semantic-release** cannot push the version tag to the branch `master` on the remote Git repository with URL `https://[secure]@github.com/activescott/lessmsi.git`.\n\nThis can be caused by:\n - a misconfiguration of the [repositoryUrl](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#repositoryurl) option\n - the repository being unavailable\n - or missing push permission for the user configured via the [Git credentials on your CI environment](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication)',

https://ci.appveyor.com/project/activescott/lessmsi/builds/52107766