### PR TITLE
poc: Try to extract an embedded .msi file

### DIFF
--- a/src/LessMsi.Core/Msi/MsiDatabase.cs
+++ b/src/LessMsi.Core/Msi/MsiDatabase.cs
@@ -23,6 +23,8 @@
 //	Scott Willeke (scott@willeke.com)
 //
 using Microsoft.Tools.WindowsInstallerXml.Msi;
+using System;
+using System.IO.MemoryMappedFiles;
 
 namespace LessMsi.Msi
 {
@@ -51,6 +53,66 @@ namespace LessMsi.Msi
 			{
 				// retry as patchfile (.msp)
 				return new Database(msiDatabaseFilePath.PathString, OpenDatabase.ReadOnly | (OpenDatabase)MSIDBOPEN_PATCHFILE);
+			}
+		}
+
+
+		static readonly Byte[] STORAGE_magic = new byte[]{ 0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1 };
+
+		public static bool TryDetectMsiHeader(LessIO.Path filePath, out long offset)
+		{
+			using (var mapped = MemoryMappedFile.CreateFromFile(filePath.PathString, System.IO.FileMode.Open, null, 0L, MemoryMappedFileAccess.ReadWrite))
+			{
+				using (var accessor = mapped.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read))
+				{
+					byte[] buffer = new byte[4096];
+					long readOffset = 0;
+					while (true)
+					{
+						int remaining = accessor.ReadArray(readOffset, buffer, 0, buffer.Length);
+						if (remaining <= 0)
+						{
+							offset = -1;
+							return false;
+						}
+
+						bool moveLess = false;
+						for (int n = 0; n < remaining; n++)
+						{
+							if (buffer[n] == STORAGE_magic[0])
+							{
+								if (buffer.Length - n >= STORAGE_magic.Length)
+								{
+									bool match = true;
+									for (int m = 1; m < STORAGE_magic.Length; m++)
+									{
+										if (buffer[n + m] != STORAGE_magic[m])
+										{
+											match = false;
+											break;
+										}
+									}
+									if (match)
+									{
+										offset = readOffset + n;
+										return true;
+									}
+								}
+								else
+								{
+									moveLess = true;
+									break;
+								}
+							}
+						}
+
+						if (moveLess && remaining > STORAGE_magic.Length && readOffset > STORAGE_magic.Length)
+						{
+							readOffset -= STORAGE_magic.Length;
+						}
+						readOffset += remaining;
+					}
+				}
 			}
 		}
 	}

--- a/src/LessMsi.Gui/IMainFormView.cs
+++ b/src/LessMsi.Gui/IMainFormView.cs
@@ -77,6 +77,8 @@ namespace LessMsi.Gui
 		/// Shows an error to the user.
 		/// </summary>
 		void ShowUserError(string formatStr, params object[] args);
+
+        bool ShowUserMessageQuestionYesNo(string message);
         /// <summary>
         /// Adds a column to the MSI table grid.
         /// </summary>

--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -54,7 +54,7 @@ namespace LessMsi.Gui
         private Panel pnlStreamsBottom;
         private Button btnExtractStreamFiles;
         private ToolStripMenuItem searchFileToolStripMenuItem;
-        readonly static string[] AllowedDragDropExtensions = new[] { ".msi", ".msp" };
+        readonly static string[] AllowedDragDropExtensions = new[] { ".msi", ".msp", ".exe" };
 
         public MainForm(string defaultInputFile)
         {
@@ -168,6 +168,12 @@ namespace LessMsi.Gui
         {
             ShowUserMessageBox(string.Format(CultureInfo.CurrentUICulture, formatStr, args));
         }
+
+        public bool ShowUserMessageQuestionYesNo(string message)
+        {
+            return MessageBox.Show(this, message, "LessMSI", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
+        }
+
 
         #region MSI Table Grid Stuff
 

--- a/src/LessMsi.Gui/MainFormPresenter.cs
+++ b/src/LessMsi.Gui/MainFormPresenter.cs
@@ -22,12 +22,6 @@
 // Authors:
 //	Scott Willeke (scott@willeke.com)
 //
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using LessIO;
 using LessMsi.Gui.Model;
 using LessMsi.Gui.Resources.Languages;
@@ -35,6 +29,13 @@ using LessMsi.Gui.Windows.Forms;
 using LessMsi.Msi;
 using LessMsi.OleStorage;
 using Microsoft.Tools.WindowsInstallerXml.Msi;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Linq;
 
 namespace LessMsi.Gui
 {
@@ -545,6 +546,25 @@ namespace LessMsi.Gui
 			}
 			catch (Exception eCatchAll)
 			{
+				if (eCatchAll is IOException && this.SelectedMsiFile.Extension.ToLower() == ".exe" && MsiDatabase.TryDetectMsiHeader(new LessIO.Path(this.SelectedMsiFile.FullName), out long offset))
+				{
+					if (View.ShowUserMessageQuestionYesNo("It looks like this file contains a .msi file, do you want to extract it?"))
+					{
+						var tempFile = System.IO.Path.GetTempFileName();
+						using (var mapped = MemoryMappedFile.CreateFromFile(this.SelectedMsiFile.FullName, FileMode.Open, null, 0L, MemoryMappedFileAccess.ReadWrite))
+						{
+							using (var reader = mapped.CreateViewStream(offset, 0, MemoryMappedFileAccess.Read))
+							{
+								using (var output = File.Create(tempFile))
+								{
+									reader.CopyTo(output);
+								}
+							}
+						}
+						LoadFile(tempFile);
+						return;
+					}
+				}
 				isBadFile = true;
 				Error(Strings.OpenFileError, eCatchAll);
 			}


### PR DESCRIPTION
This Proof of Concept code tries to find a .msi file embedded inside an .exe,
if the .exe cannot be loaded directly as msi.

This allows to inspect the .msi file from the VMware tools setup.

It is a quick & dirty implementation.

Is this something you would be interested in moving forward?
If so, please suggest changes you'd like to see.