### PR TITLE
Another update to GUI logic for japanese translation

### DIFF
--- a/src/LessMsi.Gui/MainForm.cs
+++ b/src/LessMsi.Gui/MainForm.cs
@@ -239,7 +239,7 @@ namespace LessMsi.Gui
         private TabPage tabExtractFiles;
         private TabPage tabTableView;
         public ComboBox cboTable;
-        private Label label2;
+        private Label lblTable;
         private Panel panel1;
         public Button btnExtract;
         private FolderBrowserDialog folderBrowser;
@@ -311,7 +311,7 @@ namespace LessMsi.Gui
             this.btnExtract = new System.Windows.Forms.Button();
             this.tabTableView = new System.Windows.Forms.TabPage();
             this.panel3 = new System.Windows.Forms.Panel();
-            this.label2 = new System.Windows.Forms.Label();
+            this.lblTable = new System.Windows.Forms.Label();
             this.cboTable = new System.Windows.Forms.ComboBox();
             this.msiTableGrid = new System.Windows.Forms.DataGridView();
             this.tabSummary = new System.Windows.Forms.TabPage();
@@ -500,7 +500,7 @@ namespace LessMsi.Gui
             // 
             // panel3
             // 
-            this.panel3.Controls.Add(this.label2);
+            this.panel3.Controls.Add(this.lblTable);
             this.panel3.Controls.Add(this.cboTable);
             this.panel3.Dock = System.Windows.Forms.DockStyle.Top;
             this.panel3.Location = new System.Drawing.Point(0, 0);
@@ -508,14 +508,13 @@ namespace LessMsi.Gui
             this.panel3.Size = new System.Drawing.Size(456, 28);
             this.panel3.TabIndex = 11;
             // 
-            // label2
+            // lblTable
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(4, 7);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(34, 15);
-            this.label2.TabIndex = 9;
-            this.label2.Text = Strings.Table;
+            this.lblTable.AutoSize = true;
+            this.lblTable.Name = "lblTable";
+            this.lblTable.TabIndex = 9;
+            this.lblTable.Text = Strings.Table;
+            UpdateControlWidth(this.lblTable);
             // 
             // cboTable
             // 
@@ -867,6 +866,7 @@ namespace LessMsi.Gui
             this.PerformLayout();
 
             UpdateControlLayout(panel2);
+            UpdateControlLayout(panel3);
             UpdateControlLayout(panel4);
         }
 


### PR DESCRIPTION
Hi @activescott.

@coolvitto provided some feedback on the version released today and updated his [ticket](https://github.com/activescott/lessmsi/issues/241).
I updated the GUI logic for better Japanese translation display, which is contained in this PR.

Here is the current state:
<img width="880" height="281" alt="image" src="https://github.com/user-attachments/assets/ec19024c-f53f-4fc3-b9b7-760c4411e557" />

And here is the result of my work:
<img width="691" height="256" alt="image" src="https://github.com/user-attachments/assets/80440a8a-5a39-4d90-beca-00a4dbe27253" />

Following our conversation in the previous PR, I'd like to merge this PR and solve this issue.
Once that's done, let's compile a plan to refactor and update the forms in a more general way, so new translations will not break the UI, as we see now.

Thanks.