### PR TITLE
chore: updated the help menu

### DIFF
--- a/src/LessMsi.Cli/ShowHelpCommand.cs
+++ b/src/LessMsi.Cli/ShowHelpCommand.cs
@@ -18,12 +18,13 @@ lessmsi <command> [options] <msi_name> [<path_to_extract\>] [file_names]
 
 Commands:
   x    Extracts all or specified files from the specified msi_name.
+  xo   Extracts all or specified files from the specified msi_name while overwriting files with the same name.
   xfo  Extracts all or specified files from the specified msi_name to the same folder while overwriting files with the same name.
   xfr  Extracts all or specified files from the specified msi_name to the same folder while renaming files with the same name with a count suffix.
-  l    Lists the contents of the specified msi table as CSV to stdout. Table is
-       specified with -t switch. Example: lessmsi l -t Component c:\foo.msi
-  v    Lists the value of the ProductVersion Property in the msi 
-       (typically this is the version of the MSI).
+  l    Lists the contents of the specified msi table as CSV to stdout. 
+       Table is specified with -t switch. 
+       Example: lessmsi l -t Component c:\foo.msi
+  v    Lists the value of the ProductVersion Property in the msi (typically this is the version of the MSI).
   o    Opens the specified msi_name in the GUI.
   h    Shows this help page.
 


### PR DESCRIPTION
Hi @activescott.

I've been using LessMSI and noticed that the help menu isn't updated and lacks info for the `xo` parameter.
I added that and tidied up the whole menu to look cleaner.

Here is the current help menu:
<img width="1686" height="469" alt="image" src="https://github.com/user-attachments/assets/7f393493-6d11-4bcc-aec4-a1de7e01b255" />

And here is the result of my update:
<img width="1639" height="482" alt="image" src="https://github.com/user-attachments/assets/57ab4c66-ae8a-495b-aa8b-4b3d3e33518e" />

Thank you.