### PR TITLE
chore: update funding links to feature only tip4commit

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,12 +1,3 @@
-# These are supported funding model platforms
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: activescott/lessmsi # Replace with a single IssueHunt username
-otechie: # Replace with a single Otechie username
-custom: ['https://tip4commit.com/github/activescott/lessmsi'] # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: ['https://tip4commit.com/github/activescott/lessmsi']


### PR DESCRIPTION

This should make the tip4commit link be the only link under "Sponsor" on the home page and if you click the "Sponsor" button.

I'm making this change because:

1. The other funding platforms end up being featured before tip4commit on the home page
3. Tip4commit is the only one that has ever been used by our community

Please fill out the following checklist:

- [x] Added tests for any bug fixes that changed existing code
- [x] Added tests for any new behavior
- [x] All unit tests are passing (please make sure all tests are passing for your branch/PR at https://ci.appveyor.com/project/activescott/lessmsi/history )


n/a as this does not change code :) 