### PR TITLE
fix: updated the change form logic to show languages alphabetical order

### DIFF
--- a/src/LessMsi.Gui/ChangeLanguageForm.cs
+++ b/src/LessMsi.Gui/ChangeLanguageForm.cs
@@ -48,20 +48,24 @@ namespace LessMsi.Gui
             string executingAssemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var cultureDirectories = Directory.GetDirectories(executingAssemblyPath);
 
-            var cultures = cultureDirectories
+            var cultureCodes = cultureDirectories
                 .Select(Path.GetFileName)
                 .Where(dir => !string.IsNullOrEmpty(dir))
-                .OrderBy(c => c)
                 .ToList();
 
-            cultures.Add("en");
+            cultureCodes.Add("en");
 
-            if (cultures.Any())
+            var orderedCultures = cultureCodes
+                .Distinct()
+                .Select(code => new CultureInfo(code))
+                .OrderBy(ci => ci.DisplayName)
+                .ToList();
+
+            if (orderedCultures.Any())
             {
-                foreach (var culture in cultures)
+                foreach (var cultureInfo in orderedCultures)
                 {
-                    var cultureInfo = new CultureInfo(culture);
-                    m_CultureInfoDict.Add(culture, cultureInfo);
+                    m_CultureInfoDict.Add(cultureInfo.Name, cultureInfo);
                 }
             }
         }


### PR DESCRIPTION
Hi @activescott.

I improved the change language form by showing the available languages in alphabetical order.

Here is the current state:
<img width="189" height="290" alt="image" src="https://github.com/user-attachments/assets/8daf1a6a-620b-44df-a31d-b2a536cb7dea" />

And here is the result of my work:
<img width="192" height="292" alt="image" src="https://github.com/user-attachments/assets/1d3beb12-57df-47e5-99f3-dea2b2c99c54" />

Thanks.