### PR TITLE
fix: added missing value for Save in Simplified Chinese

### DIFF
--- a/src/LessMsi.Gui/Resources/Languages/Strings.zh.resx
+++ b/src/LessMsi.Gui/Resources/Languages/Strings.zh.resx
@@ -247,7 +247,7 @@
     <value>应位于同一目录下，与</value>
   </data>
   <data name="Save" xml:space="preserve">
-    <value />
+    <value>保存</value>
   </data>
   <data name="Search" xml:space="preserve">
     <value>搜索:</value>


### PR DESCRIPTION
Hi @activescott.

I took the liberty and found the "Save" translation in Simplified Chinese, which is 保存, as shown [here](https://context.reverso.net/translation/english-chinese/save#%E4%BF%9D%E5%AD%98).

Thanks.