### PR TITLE
docs: Update GitHub stars badge style in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Chocolatey Downloads](https://img.shields.io/chocolatey/dt/lessmsi.svg?style=popout)](https://chocolatey.org/packages/lessmsi)
 [![chocolatey](https://img.shields.io/chocolatey/v/lessmsi.svg?maxAge=2592000)](https://chocolatey.org/packages/lessmsi)
 [![GitHub forks](https://img.shields.io/github/forks/activescott/lessmsi.svg)](https://github.com/activescott/lessmsi/network)
-[![GitHub stars](https://img.shields.io/github/stars/activescott/lessmsi.svg)](https://github.com/activescott/lessmsi/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/activescott/lessmsi?style=flat)](https://github.com/activescott/lessmsi/stargazers)
 [![tip for next commit](https://tip4commit.com/projects/316.svg)](https://tip4commit.com/projects/316)
 [![GitHub issues](https://img.shields.io/github/issues/activescott/lessmsi.svg)](https://github.com/activescott/lessmsi/issues)
 


### PR DESCRIPTION
Hi @activescott.

A small fix for the stars icon in the readme section.
Prior to my fix, this icon showed invalid value:
<img width="161" height="92" alt="image" src="https://github.com/user-attachments/assets/47e4fce9-470b-40f0-b5c1-3ab31fd1eed1" />

After the fix was applied, the stars icon looks like this:
<img width="161" height="92" alt="image" src="https://github.com/user-attachments/assets/c6ee30ab-e57e-4ce9-a24d-cbfd048c569c" />


Thanks.