### PR TITLE
fix: expended cmdAddShortcut's size

### DIFF
--- a/src/LessMsi.Gui/PreferencesForm.Designer.cs
+++ b/src/LessMsi.Gui/PreferencesForm.Designer.cs
@@ -42,7 +42,7 @@ namespace LessMsi.Gui
 			this.cmdAddShortcut.Location = new System.Drawing.Point(12, 16);
 			this.cmdAddShortcut.Name = "cmdAddShortcut";
 			this.cmdAddShortcut.ShowElevationShield = true;
-			this.cmdAddShortcut.Size = new System.Drawing.Size(344, 72);
+			this.cmdAddShortcut.Size = new System.Drawing.Size(344, 85);
 			this.cmdAddShortcut.TabIndex = 1;
 			this.cmdAddShortcut.Text = Strings.AddShortcutText;
 			this.cmdAddShortcut.TextNote = Strings.AddShortcutTextNote;

--- a/src/LessMsi.Gui/PreferencesForm.Designer.cs
+++ b/src/LessMsi.Gui/PreferencesForm.Designer.cs
@@ -52,7 +52,7 @@ namespace LessMsi.Gui
 			// cmdRemoveShortcut
 			// 
 			this.cmdRemoveShortcut.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.cmdRemoveShortcut.Location = new System.Drawing.Point(12, 94);
+			this.cmdRemoveShortcut.Location = new System.Drawing.Point(12, 107);
 			this.cmdRemoveShortcut.Name = "cmdRemoveShortcut";
 			this.cmdRemoveShortcut.ShowElevationShield = true;
 			this.cmdRemoveShortcut.Size = new System.Drawing.Size(344, 60);


### PR DESCRIPTION
Hi @activescott.

I've handled this [ticket](https://github.com/activescott/lessmsi/issues/294).

Before:
<img width="241" height="286" alt="bug" src="https://github.com/user-attachments/assets/f5df3b1d-8383-4388-8b60-14428f0b6061" />

After:
<img width="247" height="285" alt="fix" src="https://github.com/user-attachments/assets/d418d60e-7870-4f48-8fc3-a386562fed35" />

Thanks.